### PR TITLE
Fix version for clojars

### DIFF
--- a/makefile.docker
+++ b/makefile.docker
@@ -14,7 +14,7 @@ BUILD_SHA       ?= $(shell git rev-parse --verify HEAD)
 REPO            := rentpath/csi-linkmod
 SHORT_BUILD_SHA := $(shell echo $(BUILD_SHA) | head -c 7)
 DATE            := $(shell date -u "+%Y%m%d")
-TAG_NAME        := $(DATE)-$(BUILD_NUMBER)-$(SHORT_BUILD_SHA)
+TAG_NAME        := v$(DATE)-$(BUILD_NUMBER)-$(SHORT_BUILD_SHA)
 DOCKER_TAG      := $(REPO):$(TAG_NAME)
 
 # Build and Release are called by docker's ONBUILD step


### PR DESCRIPTION
Leiningen removes first character of tag when deploying, so add letter v to beginning of tag.

[Card](https://rentpath.leankit.com/card/649510175)